### PR TITLE
Allow the ability to optionally set keypath with SEC51_KEYPATH env var

### DIFF
--- a/file_utils.go
+++ b/file_utils.go
@@ -6,22 +6,29 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"strconv"
+	"path/filepath"
 )
 
 const (
-	keyPath     = "keys"
 	testKeyPath = "test_keys"
 )
 
 var (
-	osSeparator, _             = strconv.Unquote(strconv.QuoteRuneToASCII(os.PathSeparator))
-	keysFolderPrefixFormat     = fmt.Sprintf("%s%s", keyPath, osSeparator) + "%s"
-	testKeysFolderPrefixFormat = fmt.Sprintf("%s%s", testKeyPath, osSeparator) + "%s"
+	keyPath                    string
+	keysFolderPrefixFormat     string
+	testKeysFolderPrefixFormat string
 )
 
 // create the keys folder if it does not exist, with the proper permission
 func init() {
+	if os.Getenv("SEC51_KEYPATH") != "" {
+		keyPath = os.Getenv("SEC51_KEYPATH")
+	} else {
+		keyPath = "keys"
+	}
+
+	keysFolderPrefixFormat = filepath.Join(keyPath, "%s")
+	testKeysFolderPrefixFormat = filepath.Join(testKeyPath, "%s")
 	if err := createBaseKeyFolder(keyPath); err != nil {
 		log.Println(err)
 	}


### PR DESCRIPTION
I just incorporated your twofactor package into my web app.  It was easy and awesome, thanks!

However, when I deploy my app I'd like to be able to control where the keys dir lives.  I'd love it if you could accept this PR and update the vendor of twofactor to include the change.

Thanks,

Craig
